### PR TITLE
301 support

### DIFF
--- a/lib/animator.lua
+++ b/lib/animator.lua
@@ -108,6 +108,7 @@ function animator.count()
   local metroFree = metro.free
   local output = OUTPUTS[params:get('output')]
   local jfPlayNote = crow.ii.jf.play_note
+  local er_port = params:get('ER_port')
 
   local useMidiCheck = {[MIDI] = true, [AUDIO_MIDI] = true}
   local useMidi = useMidiCheck[output]
@@ -127,7 +128,7 @@ function animator.count()
   local currentCrowOut = 1
   local crowCVPlayed = 0
 
-  local currentSCOut = 1
+  local currentSCOut = 0 + er_port
   local scCVPlayed = 0
 
   local function playNote(note, channel)
@@ -142,11 +143,11 @@ function animator.count()
       crowCVPlayed = crowCVPlayed + 1
     end
 
-    -- ER 301 additions
+    -- ER 301 support
     if useSC and scCVPlayed < 8 then
       crow.ii.er301.cv(currentSCOut ,(note-60)/12)
       crow.ii.er301.tr_pulse(currentSCOut)
-      currentSCOut = (currentSCOut + 1) % 8
+      currentSCOut = ((currentSCOut + 1) % 8)
       scCVPlayed = scCVPlayed + 1
     end
     --

--- a/lib/animator.lua
+++ b/lib/animator.lua
@@ -9,7 +9,6 @@ local MIDI = constants.OUTPUT_MIDI
 local AUDIO_MIDI = constants.OUTPUT_AUDIO_MIDI
 local CROW_II_JF = constants.OUTPUT_CROW_II_JF
 local CROW_II_SC = constants.OUTPUT_CROW_II_SC
-local CROW_II_TXO = constants.OUTPUT_CROW_II_TXO
 local CROW_CV = constants.OUTPUT_CROW_CV
 local CROW_CV_JF = constants.OUTPUT_CROW_CV_JF
 local AUDIO_CV_JF = constants.OUTPUT_AUDIO_CV_JF
@@ -124,9 +123,6 @@ function animator.count()
   local useSCCheck = {[CROW_II_SC] = true}
   local useSC = useSCCheck[output]
 
-  local useTXoCheck = {[CROW_II_TXO] = true}
-  local useTXo = useTXoCheck[output]
-
   local useCVCheck = {[CROW_CV] = true, [CROW_CV_JF] = true, [AUDIO_CV_JF] = true}
   local useCV = useCVCheck[output]
 
@@ -135,9 +131,6 @@ function animator.count()
 
   local currentSCOut = -1 + er_port
   local scCVPlayed = 0
-
-  local currentTXoOut = 0
-  local txoCVPlayed = 0
 
   local function playNote(note, channel)
     if useJF then
@@ -157,14 +150,6 @@ function animator.count()
       crow.ii.er301.tr_pulse(currentSCOut + 1)
       currentSCOut = ((currentSCOut + 1) % 8)
       scCVPlayed = scCVPlayed + 1
-    end
-    --
-    -- TXo support
-    if useTXo and txoCVPlayed <= 8 then
-      crow.ii.txo.cv(currentTXoOut + 1,(note-60)/12)
-      crow.ii.txo.tr_pulse(currentTXoOut + 1)
-      currentTXoOut = ((currentTXoOut + 1) % 4)
-      txoCVPlayed = txoCVPlayed + 1
     end
     --
 

--- a/lib/animator.lua
+++ b/lib/animator.lua
@@ -9,6 +9,7 @@ local MIDI = constants.OUTPUT_MIDI
 local AUDIO_MIDI = constants.OUTPUT_AUDIO_MIDI
 local CROW_II_JF = constants.OUTPUT_CROW_II_JF
 local CROW_II_SC = constants.OUTPUT_CROW_II_SC
+local CROW_II_TXO = constants.OUTPUT_CROW_II_TXO
 local CROW_CV = constants.OUTPUT_CROW_CV
 local CROW_CV_JF = constants.OUTPUT_CROW_CV_JF
 local AUDIO_CV_JF = constants.OUTPUT_AUDIO_CV_JF
@@ -122,14 +123,20 @@ function animator.count()
   local useSCCheck = {[CROW_II_SC] = true}
   local useSC = useSCCheck[output]
 
+  local useTXoCheck = {[CROW_II_TXO] = true}
+  local useTXo = useTXoCheck[output]
+
   local useCVCheck = {[CROW_CV] = true, [CROW_CV_JF] = true, [AUDIO_CV_JF] = true}
   local useCV = useCVCheck[output]
 
   local currentCrowOut = 1
   local crowCVPlayed = 0
 
-  local currentSCOut = 0 + er_port
+  local currentSCOut = -1 + er_port
   local scCVPlayed = 0
+
+  local currentTXoOut = 0
+  local txoCVPlayed = 0
 
   local function playNote(note, channel)
     if useJF then
@@ -144,11 +151,19 @@ function animator.count()
     end
 
     -- ER 301 support
-    if useSC and scCVPlayed < 8 then
-      crow.ii.er301.cv(currentSCOut ,(note-60)/12)
-      crow.ii.er301.tr_pulse(currentSCOut)
+    if useSC and scCVPlayed <= 8 then
+      crow.ii.er301.cv(currentSCOut + 1,(note-60)/12)
+      crow.ii.er301.tr_pulse(currentSCOut + 1)
       currentSCOut = ((currentSCOut + 1) % 8)
       scCVPlayed = scCVPlayed + 1
+    end
+    --
+    -- TXo support
+    if useTXo and txoCVPlayed <= 8 then
+      crow.ii.txo.cv(currentTXoOut + 1,(note-60)/12)
+      crow.ii.txo.tr_pulse(currentTXoOut + 1)
+      currentTXoOut = ((currentTXoOut + 1) % 4)
+      txoCVPlayed = txoCVPlayed + 1
     end
     --
 

--- a/lib/animator.lua
+++ b/lib/animator.lua
@@ -129,7 +129,7 @@ function animator.count()
   local currentCrowOut = 1
   local crowCVPlayed = 0
 
-  local currentSCOut = -1 + er_port
+  local currentSCOut = 0
   local scCVPlayed = 0
 
   local function playNote(note, channel)
@@ -146,9 +146,9 @@ function animator.count()
 
     -- ER 301 support
     if useSC and scCVPlayed <= 8 then
-      crow.ii.er301.cv(currentSCOut + 1,(note-60)/12)
-      crow.ii.er301.tr_pulse(currentSCOut + 1)
-      currentSCOut = ((currentSCOut + 1) % 8)
+      crow.ii.er301.cv(currentSCOut + er_port,(note-60)/12)
+      crow.ii.er301.tr_pulse(currentSCOut + er_port)
+      currentSCOut = (currentSCOut + 1) % 8
       scCVPlayed = scCVPlayed + 1
     end
     --

--- a/lib/animator.lua
+++ b/lib/animator.lua
@@ -8,6 +8,7 @@ local AUDIO = constants.OUTPUT_AUDIO
 local MIDI = constants.OUTPUT_MIDI
 local AUDIO_MIDI = constants.OUTPUT_AUDIO_MIDI
 local CROW_II_JF = constants.OUTPUT_CROW_II_JF
+local CROW_II_SC = constants.OUTPUT_CROW_II_SC
 local CROW_CV = constants.OUTPUT_CROW_CV
 local CROW_CV_JF = constants.OUTPUT_CROW_CV_JF
 local AUDIO_CV_JF = constants.OUTPUT_AUDIO_CV_JF
@@ -117,11 +118,17 @@ function animator.count()
   local useJFCheck = {[CROW_II_JF] = true, [CROW_CV_JF] = true, [AUDIO_CV_JF] = true}
   local useJF = useJFCheck[output]
 
+  local useSCCheck = {[CROW_II_SC] = true}
+  local useSC = useSCCheck[output]
+
   local useCVCheck = {[CROW_CV] = true, [CROW_CV_JF] = true, [AUDIO_CV_JF] = true}
   local useCV = useCVCheck[output]
 
   local currentCrowOut = 1
   local crowCVPlayed = 0
+
+  local currentSCOut = 1
+  local scCVPlayed = 0
 
   local function playNote(note, channel)
     if useJF then
@@ -134,6 +141,15 @@ function animator.count()
       currentCrowOut = (currentCrowOut + 2) % 4
       crowCVPlayed = crowCVPlayed + 1
     end
+
+    -- ER 301 additions
+    if useSC and scCVPlayed < 8 then
+      crow.ii.er301.cv(currentSCOut ,(note-60)/12)
+      crow.ii.er301.tr_pulse(currentSCOut)
+      currentSCOut = (currentSCOut + 1) % 8
+      scCVPlayed = scCVPlayed + 1
+    end
+    --
 
     if useAudio or useMidi then
       local velocity = random(minVel, maxVel)

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -12,7 +12,7 @@ local CROW_II_JF = 'crow ii jf'
 local CROW_CV = 'crow cv'
 local CROW_CV_JF = 'crow cv + JF'
 local AUDIO_CV_JF = 'audio + cv + JF'
-local SC = 'ER-301'
+local CROW_II_SC = 'ER-301'
 local GRID_LENGTH = 16
 local GRID_HEIGHT = 8
 

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -9,10 +9,11 @@ local AUDIO = 'audio'
 local MIDI = 'midi'
 local AUDIO_MIDI = 'audio + midi'
 local CROW_II_JF = 'crow ii jf'
+local CROW_II_SC = 'ER-301'
+local CROW_II_TXO = 'TXo'
 local CROW_CV = 'crow cv'
 local CROW_CV_JF = 'crow cv + JF'
 local AUDIO_CV_JF = 'audio + cv + JF'
-local CROW_II_SC = 'ER-301'
 local GRID_LENGTH = 16
 local GRID_HEIGHT = 8
 
@@ -39,7 +40,8 @@ local constants = {
   OUTPUT_CROW_CV_JF = CROW_CV_JF,
   OUTPUT_AUDIO_CV_JF = AUDIO_CV_JF,
   OUTPUT_CROW_II_SC = CROW_II_SC,
-  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF, CROW_II_SC},
+  OUTPUT_CROW_II_TXO = CROW_II_TXO,
+  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF, CROW_II_SC, CROW_II_TXO},
   EVENT_PATTERN = 'pattern',
   EVENT_SNAPSHOT = 'snapshot'
 }

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -10,7 +10,6 @@ local MIDI = 'midi'
 local AUDIO_MIDI = 'audio + midi'
 local CROW_II_JF = 'crow ii jf'
 local CROW_II_SC = 'ER-301'
-local CROW_II_TXO = 'TXo'
 local CROW_CV = 'crow cv'
 local CROW_CV_JF = 'crow cv + JF'
 local AUDIO_CV_JF = 'audio + cv + JF'
@@ -40,8 +39,7 @@ local constants = {
   OUTPUT_CROW_CV_JF = CROW_CV_JF,
   OUTPUT_AUDIO_CV_JF = AUDIO_CV_JF,
   OUTPUT_CROW_II_SC = CROW_II_SC,
-  OUTPUT_CROW_II_TXO = CROW_II_TXO,
-  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF, CROW_II_SC, CROW_II_TXO},
+  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF, CROW_II_SC},
   EVENT_PATTERN = 'pattern',
   EVENT_SNAPSHOT = 'snapshot'
 }

--- a/lib/constants.lua
+++ b/lib/constants.lua
@@ -12,6 +12,7 @@ local CROW_II_JF = 'crow ii jf'
 local CROW_CV = 'crow cv'
 local CROW_CV_JF = 'crow cv + JF'
 local AUDIO_CV_JF = 'audio + cv + JF'
+local SC = 'ER-301'
 local GRID_LENGTH = 16
 local GRID_HEIGHT = 8
 
@@ -37,7 +38,8 @@ local constants = {
   OUTPUT_CROW_CV = CROW_CV,
   OUTPUT_CROW_CV_JF = CROW_CV_JF,
   OUTPUT_AUDIO_CV_JF = AUDIO_CV_JF,
-  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF},
+  OUTPUT_CROW_II_SC = CROW_II_SC,
+  OUTPUTS = {AUDIO, MIDI, AUDIO_MIDI, CROW_II_JF, CROW_CV, CROW_CV_JF, AUDIO_CV_JF, CROW_II_SC},
   EVENT_PATTERN = 'pattern',
   EVENT_SNAPSHOT = 'snapshot'
 }

--- a/lib/parameters.lua
+++ b/lib/parameters.lua
@@ -67,7 +67,7 @@ function parameters.init(animator)
   params:add_trigger('load', 'load doodle')
   params:set_action('load', function() fileselect.enter(norns.state.data, animator.load) end)
 
-  params:add_group('SETTINGS', 7)
+  params:add_group('SETTINGS', 8)
   params:add_option('output', 'output', constants.OUTPUTS, 1)
   params:set_action('output', function(v)
     local output = constants.OUTPUTS[v]
@@ -87,6 +87,8 @@ function parameters.init(animator)
       crow.output[4].action = triggerASL
     end
   end)
+  params:add_number('ER_port', 'ER-301 port', 1, 90, 1) -- sets 301 port bias
+
   params:add_option('scale', 'scale', getScaleNames(), 1)
   params:set_action('scale', function(scale)
     animator.notes = mapGridNotes(scale, params:get('global_transpose'))


### PR DESCRIPTION
Adds support for ER-301 via Crow and ii
Up to eight voices (SC.TR.P + SC.CV) 
ER-301 output selectable in settings -> outputs
+ an option to set the port bias (lowest port used on the ER-301) in the same menu.